### PR TITLE
Update cypher query

### DIFF
--- a/app/improving_agent/src/core.py
+++ b/app/improving_agent/src/core.py
@@ -77,7 +77,6 @@ def process_query(raw_json):
     qnodes = validate_normalize_qnodes(query_graph.nodes)
     qedges = validate_normalize_qedges(query_graph)
 
-    # TODO: logic for different query types
     querier = BasicQuery(qnodes, qedges, query_options, query.max_results)
 
     # now query SPOKE
@@ -98,7 +97,7 @@ def try_query(query):
     except UnmatchedIdentifierError as e:
         return Response(Message(), status=200, description=f'{str(e)}; returning empty message...'), 200
     except Exception as e:
-        logger.error(str(e))
+        logger.exception(str(e))
         timestamp = datetime.now().isoformat()
         error_description = (
             'Something went wrong. If this error is reproducible using the same '

--- a/app/improving_agent/src/kps/biggim.py
+++ b/app/improving_agent/src/kps/biggim.py
@@ -9,6 +9,10 @@ from improving_agent.util import get_evidara_logger
 logger = get_evidara_logger(__name__)
 
 
+def format_gene_for_bg(identifier):
+    return int(format_gene_for_spoke(identifier))
+
+
 def get_relevant_anatomy(session, disease):
     """Returns SPOKE results for anatomy related to `disease`
     Parameters
@@ -105,7 +109,7 @@ def annotate_edges_with_biggim(
         edges_to_update = []
         for result in results:
             for bg_node in bg_nodes:
-                genes_to_search.add(format_gene_for_spoke(result.node_bindings[bg_node.qnode_id].id))
+                genes_to_search.add(format_gene_for_bg(result.node_bindings[bg_node.qnode_id].id))
             for bg_edge in bg_edges:
                 edges_to_update.append(result.edge_bindings[bg_edge.qedge_id].id)
 
@@ -123,12 +127,13 @@ def annotate_edges_with_biggim(
         for edge_id in edges_to_update:
             kedge = kg_edges[edge_id]
 
-            # TODO: Python 3.8+ update - take care of these ugly assignments with key :=
             key = None
-            if f"{format_gene_for_spoke(kedge.subject)}-{format_gene_for_spoke(kedge.object)}" in bg_results:
-                key = f"{format_gene_for_spoke(kedge.subject)}-{format_gene_for_spoke(kedge.object)}"
-            elif f"{format_gene_for_spoke(kedge.object)}-{format_gene_for_spoke(kedge.subject)}" in bg_results:
-                key = f"{format_gene_for_spoke(kedge.object)}-{format_gene_for_spoke(kedge.subject)}"
+            formatted_subject = format_gene_for_bg(kedge.subject)
+            formatted_object = format_gene_for_bg(kedge.object)
+            if f"{formatted_subject}-{formatted_object}" in bg_results:
+                key = f"{formatted_subject}-{formatted_object}"
+            elif f"{formatted_object}-{formatted_subject}" in bg_results:
+                key = f"{formatted_object}-{formatted_subject}"
             else:
                 continue
 

--- a/app/improving_agent/src/normalization/curie_formatters.py
+++ b/app/improving_agent/src/normalization/curie_formatters.py
@@ -148,80 +148,79 @@ def register_spoke_curie_formatter(node_type, regex):
 
 @register_spoke_curie_formatter(SPOKE_LABEL_ANATOMY, SPOKE_IDENTIFIER_REGEX_ANATOMY)
 def _format_anatomy_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_BIOLOGICAL_PROCESS, SPOKE_IDENTIFIER_REGEX_BIOLOGICAL_PROCESS)
 def _format_biological_process_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_CELL_TYPE, SPOKE_IDENTIFIER_REGEX_CELL_TYPE)
 def _format_cell_type_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_CELLULAR_COMPONENT, SPOKE_IDENTIFIER_REGEX_CELLULAR_COMPONENT)
 def _format_cellular_component_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_COMPOUND, '^CHEMBL.COMPOUND:|^DRUGBANK:')
 def _format_compound_for_spoke(curie):
-    return re.sub('^CHEMBL.COMPOUND:|^DRUGBANK:', '', curie)
+    return f"'{re.sub('^CHEMBL.COMPOUND:|^DRUGBANK:', '', curie)}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_DISEASE, SPOKE_IDENTIFIER_REGEX_DISEASE)
 def _format_disease_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_FOOD, SPOKE_IDENTIFIER_REGEX_FOOD)
 def _format_food_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_GENE, '^NCBIGene:')
 def format_gene_for_spoke(curie):
     # missing leading underscore because it's used by the BigGIM module
     return curie.replace('NCBIGene:', '')
-    # this ^ is an int in SPOKE, but we keep a string here and forego
-    # addition of quotes when returning it below
+    # this ^ is an int in SPOKE, but we just forego the addition of quotes here
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_MOLECULAR_FUNCTION, SPOKE_IDENTIFIER_REGEX_MOLECULAR_FUNCTION)
 def _format_molecular_function_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_NUTRIENT, SPOKE_IDENTIFIER_REGEX_NUTRIENT)
 def _format_nutrient_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_PATHWAY, SPOKE_IDENTIFIER_REGEX_PATHWAY)
 def _format_pathway_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_PHARMACOLOGIC_CLASS, SPOKE_IDENTIFIER_REGEX_PHARMACOLOGIC_CLASS)
 def _format_pharmacological_class_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_PROTEIN, '^UniProtKB:')
 def _format_protein_for_spoke(curie):
-    return curie.replace('UniProtKB:', '')
+    return f"'{curie.replace('UniProtKB:', '')}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_SIDE_EFFECT, SPOKE_IDENTIFIER_REGEX_SIDE_EFFECT)
 def _format_side_effect_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 @register_spoke_curie_formatter(SPOKE_LABEL_SYMPTOM, '^MESH:D[0-9]+')
 def _format_symptom_for_spoke(curie):
-    return curie
+    return f"'{curie}'"
 
 
 def get_label_if_appropriate_spoke_curie(spoke_labels, curie):
@@ -251,11 +250,6 @@ def get_spoke_identifier_from_normalized_node(spoke_labels, normalized_node, sea
                     node_type_config[NODE_NORMALIZATION_KEY_REGEX],
                     identifier[NODE_NORMALIZATION_RESPONSE_VALUE_IDENTIFIER]
             ):
-                spoke_identifier = node_type_config[NODE_NORMALIZATION_KEY_FUNCTION](
+                return node_type_config[NODE_NORMALIZATION_KEY_FUNCTION](
                     identifier[NODE_NORMALIZATION_RESPONSE_VALUE_IDENTIFIER]
                 )
-
-                # quote formatting for Cypher IN clause
-                if node_type_config[NODE_NORMALIZATION_KEY_REGEX] == '^NCBIGene:':  # unfortunate hack for gene
-                    return spoke_identifier
-                return f"'{spoke_identifier}'"

--- a/app/improving_agent/util.py
+++ b/app/improving_agent/util.py
@@ -7,7 +7,7 @@ import six
 from improving_agent import typing_utils
 from improving_agent.src.config import LOG_LOCATION
 
-formatter = logging.Formatter("%(asctime)s %(name)s %(lineno)d %(levelname)s %(message)s")
+formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s line %(lineno)d: %(message)s')
 
 
 def _deserialize(data, klass):

--- a/app/improving_agent/util.py
+++ b/app/improving_agent/util.py
@@ -7,7 +7,7 @@ import six
 from improving_agent import typing_utils
 from improving_agent.src.config import LOG_LOCATION
 
-formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+formatter = logging.Formatter("%(asctime)s %(name)s %(lineno)d %(levelname)s %(message)s")
 
 
 def _deserialize(data, klass):


### PR DESCRIPTION
This changes the Cypher query from a highly specified match clause e.g.:
```
MATCH (a:Gene {identifier: 1234})-[b:ASSOCIATES_DaG]-(c:Disease)
RETURN *
```
to instead have multiple where clauses. This was done in order to accommodate multiple labels and multiple identifiers for each query node. The above now looks like the following:
```
MATCH (a)-[b:ASSOCIATES_DaG]-(c)
WHERE ((a:Gene) and a.identifier IN [1234])
  AND (c:Disease)
RETURN *
```